### PR TITLE
Fix exception when calling isMethodSafe() without arguments

### DIFF
--- a/src/Http/Middleware/LockingMiddleware.php
+++ b/src/Http/Middleware/LockingMiddleware.php
@@ -64,7 +64,7 @@ class LockingMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        if ($request->isMethodSafe() || $this->shouldPassThrough($request)) {
+        if ($request->isMethodSafe(false) || $this->shouldPassThrough($request)) {
             return $next($request);
         }
 


### PR DESCRIPTION
Fix https://github.com/AltThree/Locker/issues/16